### PR TITLE
Replace boost with std in DC-SAM.

### DIFF
--- a/include/dcsam/DCContinuousFactor.h
+++ b/include/dcsam/DCContinuousFactor.h
@@ -40,7 +40,7 @@ namespace dcsam {
 class DCContinuousFactor : public gtsam::NonlinearFactor {
  private:
   gtsam::DiscreteKeys discreteKeys_;
-  boost::shared_ptr<DCFactor> dcfactor_;
+  std::shared_ptr<DCFactor> dcfactor_;
   DiscreteValues discreteVals_;
 
  public:
@@ -48,7 +48,7 @@ class DCContinuousFactor : public gtsam::NonlinearFactor {
 
   DCContinuousFactor() = default;
 
-  explicit DCContinuousFactor(boost::shared_ptr<DCFactor> dcfactor)
+  explicit DCContinuousFactor(std::shared_ptr<DCFactor> dcfactor)
       : discreteKeys_(dcfactor->discreteKeys()), dcfactor_(dcfactor) {
     keys_ = dcfactor->keys();
   }
@@ -58,7 +58,7 @@ class DCContinuousFactor : public gtsam::NonlinearFactor {
     return dcfactor_->error(continuousVals, discreteVals_);
   }
 
-  boost::shared_ptr<gtsam::GaussianFactor> linearize(
+  std::shared_ptr<gtsam::GaussianFactor> linearize(
       const gtsam::Values& continuousVals) const override {
     assert(allInitialized());
     return dcfactor_->linearize(continuousVals, discreteVals_);

--- a/include/dcsam/DCDiscreteFactor.h
+++ b/include/dcsam/DCDiscreteFactor.h
@@ -42,7 +42,7 @@ class DCDiscreteFactor : public gtsam::DiscreteFactor {
  private:
   gtsam::DiscreteKeys discreteKeys_;
   gtsam::KeyVector continuousKeys_;
-  boost::shared_ptr<DCFactor> dcfactor_;
+  std::shared_ptr<DCFactor> dcfactor_;
   gtsam::Values continuousVals_;
   DiscreteValues discreteVals_;
 
@@ -52,7 +52,7 @@ class DCDiscreteFactor : public gtsam::DiscreteFactor {
   DCDiscreteFactor() = default;
 
   DCDiscreteFactor(const gtsam::DiscreteKeys& discreteKeys,
-                   boost::shared_ptr<DCFactor> dcfactor)
+                   std::shared_ptr<DCFactor> dcfactor)
       : discreteKeys_(discreteKeys),
         continuousKeys_(dcfactor->keys()),
         dcfactor_(dcfactor) {
@@ -61,7 +61,7 @@ class DCDiscreteFactor : public gtsam::DiscreteFactor {
     for (const gtsam::DiscreteKey& k : discreteKeys_) keys_.push_back(k.first);
   }
 
-  explicit DCDiscreteFactor(boost::shared_ptr<DCFactor> dcfactor)
+  explicit DCDiscreteFactor(std::shared_ptr<DCFactor> dcfactor)
       : discreteKeys_(dcfactor->discreteKeys()),
         continuousKeys_(dcfactor->keys()),
         dcfactor_(dcfactor) {

--- a/include/dcsam/DCEMFactor.h
+++ b/include/dcsam/DCEMFactor.h
@@ -150,10 +150,10 @@ class DCEMFactor : public DCFactor {
   /*
    * Jacobian magic
    */
-  boost::shared_ptr<gtsam::GaussianFactor> linearize(
+  std::shared_ptr<gtsam::GaussianFactor> linearize(
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const override {
-    std::vector<boost::shared_ptr<gtsam::GaussianFactor>> gfs;
+    std::vector<std::shared_ptr<gtsam::GaussianFactor>> gfs;
 
     // Start by computing all errors, so we can get the component weights.
     std::vector<double> errors =
@@ -169,7 +169,7 @@ class DCEMFactor : public DCFactor {
     for (size_t i = 0; i < factors_.size(); i++) {
       // std::cout << "i = " << i << std::endl;
       // First get the GaussianFactor obtained by linearizing `factors_[i]`
-      boost::shared_ptr<gtsam::GaussianFactor> gf =
+      std::shared_ptr<gtsam::GaussianFactor> gf =
           factors_[i].linearize(continuousVals, discreteVals);
 
       gtsam::JacobianFactor jf_component(*gf);
@@ -197,7 +197,7 @@ class DCEMFactor : public DCFactor {
 
     // Stack Jacobians to build combined factor.
 
-    return boost::make_shared<gtsam::JacobianFactor>(gfg);
+    return std::make_shared<gtsam::JacobianFactor>(gfg);
   }
 
   gtsam::DecisionTreeFactor toDecisionTreeFactor(

--- a/include/dcsam/DCFactor.h
+++ b/include/dcsam/DCFactor.h
@@ -99,7 +99,7 @@ class DCFactor : public gtsam::Factor {
    * @param discreteVals - Likewise, assignment to the discrete variables in
    * `discreteKeys__`.
    */
-  virtual boost::shared_ptr<gtsam::GaussianFactor> linearize(
+  virtual std::shared_ptr<gtsam::GaussianFactor> linearize(
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const = 0;
 
@@ -196,22 +196,22 @@ class DCFactor : public gtsam::Factor {
     gtsam::Matrix infoMat;
 
     // NOTE: This is sloppy, is there a cleaner way?
-    boost::shared_ptr<NonlinearFactorType> fPtr =
-        boost::make_shared<NonlinearFactorType>(factor);
-    boost::shared_ptr<NonlinearFactorType> factorPtr(fPtr);
+    std::shared_ptr<NonlinearFactorType> fPtr =
+        std::make_shared<NonlinearFactorType>(factor);
+    std::shared_ptr<NonlinearFactorType> factorPtr(fPtr);
 
     // If this is a NoiseModelFactor, we'll use its noiseModel to
     // otherwise noiseModelFactor will be nullptr
-    boost::shared_ptr<gtsam::NoiseModelFactor> noiseModelFactor =
-        boost::dynamic_pointer_cast<gtsam::NoiseModelFactor>(factorPtr);
+    std::shared_ptr<gtsam::NoiseModelFactor> noiseModelFactor =
+        std::dynamic_pointer_cast<gtsam::NoiseModelFactor>(factorPtr);
     if (noiseModelFactor) {
       // If dynamic cast to NoiseModelFactor succeeded, see if the noise model
       // is Gaussian
       gtsam::noiseModel::Base::shared_ptr noiseModel =
           noiseModelFactor->noiseModel();
 
-      boost::shared_ptr<gtsam::noiseModel::Gaussian> gaussianNoiseModel =
-          boost::dynamic_pointer_cast<gtsam::noiseModel::Gaussian>(noiseModel);
+      std::shared_ptr<gtsam::noiseModel::Gaussian> gaussianNoiseModel =
+          std::dynamic_pointer_cast<gtsam::noiseModel::Gaussian>(noiseModel);
       if (gaussianNoiseModel) {
         // If the noise model is Gaussian, retrieve the information matrix
         infoMat = gaussianNoiseModel->information();
@@ -220,7 +220,7 @@ class DCFactor : public gtsam::Factor {
         // something with a normalized noise model
         // TODO(kevin): does this make sense to do? I think maybe not in
         // general? Should we just yell at the user?
-        boost::shared_ptr<gtsam::GaussianFactor> gaussianFactor =
+        std::shared_ptr<gtsam::GaussianFactor> gaussianFactor =
             factor.linearize(values);
         infoMat = gaussianFactor->information();
       }

--- a/include/dcsam/DCMaxMixtureFactor.h
+++ b/include/dcsam/DCMaxMixtureFactor.h
@@ -120,7 +120,7 @@ class DCMaxMixtureFactor : public DCFactor {
     return ((log_weights_ == f.log_weights_) && (normalized_ == f.normalized_));
   }
 
-  boost::shared_ptr<gtsam::GaussianFactor> linearize(
+  std::shared_ptr<gtsam::GaussianFactor> linearize(
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const override {
     size_t min_error_idx = getActiveFactorIdx(continuousVals, discreteVals);

--- a/include/dcsam/DCMixtureFactor.h
+++ b/include/dcsam/DCMixtureFactor.h
@@ -102,7 +102,7 @@ class DCMixtureFactor : public DCFactor {
             (normalized_ == f.normalized_));
   }
 
-  boost::shared_ptr<gtsam::GaussianFactor> linearize(
+  std::shared_ptr<gtsam::GaussianFactor> linearize(
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const override {
     // Retrieve the assignment to our discrete key.

--- a/include/dcsam/HybridFactorGraph.h
+++ b/include/dcsam/HybridFactorGraph.h
@@ -37,15 +37,15 @@ class HybridFactorGraph {
   template <typename NonlinearFactorType>
   void push_nonlinear(const NonlinearFactorType &nonlinearFactor) {
     nonlinearGraph_.push_back(
-        boost::make_shared<NonlinearFactorType>(nonlinearFactor));
+        std::make_shared<NonlinearFactorType>(nonlinearFactor));
   }
 
   /**
    * Add a nonlinear factor *pointer* to the internal nonlinear factor graph
-   * @param nonlinearFactor - boost::shared_ptr to the factor to add
+   * @param nonlinearFactor - std::shared_ptr to the factor to add
    */
   void push_nonlinear(
-      boost::shared_ptr<gtsam::NonlinearFactor> nonlinearFactor);
+      std::shared_ptr<gtsam::NonlinearFactor> nonlinearFactor);
 
   /**
    * Add a discrete factor to the internal discrete graph
@@ -54,14 +54,14 @@ class HybridFactorGraph {
   template <typename DiscreteFactorType>
   void push_discrete(const DiscreteFactorType &discreteFactor) {
     discreteGraph_.push_back(
-        boost::make_shared<DiscreteFactorType>(discreteFactor));
+        std::make_shared<DiscreteFactorType>(discreteFactor));
   }
 
   /**
    * Add a discrete factor *pointer* to the internal discrete graph
-   * @param discreteFactor - boost::shared_ptr to the factor to add
+   * @param discreteFactor - std::shared_ptr to the factor to add
    */
-  void push_discrete(boost::shared_ptr<gtsam::DiscreteFactor> discreteFactor);
+  void push_discrete(std::shared_ptr<gtsam::DiscreteFactor> discreteFactor);
 
   /**
    * Add a discrete-continuous (DC) factor to the internal DC graph
@@ -69,14 +69,14 @@ class HybridFactorGraph {
    */
   template <typename DCFactorType>
   void push_dc(const DCFactorType &dcFactor) {
-    dcGraph_.push_back(boost::make_shared<DCFactorType>(dcFactor));
+    dcGraph_.push_back(std::make_shared<DCFactorType>(dcFactor));
   }
 
   /**
    * Add a discrete-continuous (DC) factor *pointer* to the internal DC graph
-   * @param dcFactor - boost::shared_ptr to the factor to add
+   * @param dcFactor - std::shared_ptr to the factor to add
    */
-  void push_dc(boost::shared_ptr<DCFactor> dcFactor);
+  void push_dc(std::shared_ptr<DCFactor> dcFactor);
 
   /**
    * Simply prints the factor graph.

--- a/include/dcsam/SemanticBearingRangeFactor.h
+++ b/include/dcsam/SemanticBearingRangeFactor.h
@@ -89,7 +89,7 @@ class SemanticBearingRangeFactor : public DCFactor {
   // dim is the dimension of the underlying bearingrange factor
   size_t dim() const override { return factor_.dim(); }
 
-  boost::shared_ptr<gtsam::GaussianFactor> linearize(
+  std::shared_ptr<gtsam::GaussianFactor> linearize(
       const gtsam::Values& continuousVals,
       const DiscreteValues& discreteVals) const override {
     return factor_.linearize(continuousVals);

--- a/src/DCSAM.cpp
+++ b/src/DCSAM.cpp
@@ -65,7 +65,7 @@ void DCSAM::update(const gtsam::NonlinearFactorGraph &graph,
   for (auto &dcfactor : dcfg) {
     DCDiscreteFactor dcDiscreteFactor(dcfactor);
     auto sharedDiscrete =
-        boost::make_shared<DCDiscreteFactor>(dcDiscreteFactor);
+        std::make_shared<DCDiscreteFactor>(dcDiscreteFactor);
     discreteCombined.push_back(sharedDiscrete);
     dcDiscreteFactors_.push_back(sharedDiscrete);
   }
@@ -84,7 +84,7 @@ void DCSAM::update(const gtsam::NonlinearFactorGraph &graph,
   for (auto &dcfactor : dcfg) {
     DCContinuousFactor dcContinuousFactor(dcfactor);
     auto sharedContinuous =
-        boost::make_shared<DCContinuousFactor>(dcContinuousFactor);
+        std::make_shared<DCContinuousFactor>(dcContinuousFactor);
     sharedContinuous->updateDiscrete(currDiscrete_);
     combined.push_back(sharedContinuous);
     dcContinuousFactors_.push_back(sharedContinuous);
@@ -124,8 +124,8 @@ void DCSAM::updateDiscreteInfo(const gtsam::Values &continuousVals,
                                const DiscreteValues &discreteVals) {
   if (continuousVals.empty()) return;
   for (auto factor : dcDiscreteFactors_) {
-    boost::shared_ptr<DCDiscreteFactor> dcDiscrete =
-        boost::static_pointer_cast<DCDiscreteFactor>(factor);
+    std::shared_ptr<DCDiscreteFactor> dcDiscrete =
+        std::static_pointer_cast<DCDiscreteFactor>(factor);
     dcDiscrete->updateContinuous(continuousVals);
     dcDiscrete->updateDiscrete(discreteVals);
   }
@@ -142,8 +142,8 @@ void DCSAM::updateContinuousInfo(const DiscreteValues &discreteVals,
   gtsam::ISAM2UpdateParams updateParams;
   gtsam::FastMap<gtsam::FactorIndex, gtsam::KeySet> newAffectedKeys;
   for (size_t j = 0; j < dcContinuousFactors_.size(); j++) {
-    boost::shared_ptr<DCContinuousFactor> dcContinuousFactor =
-        boost::static_pointer_cast<DCContinuousFactor>(dcContinuousFactors_[j]);
+    std::shared_ptr<DCContinuousFactor> dcContinuousFactor =
+        std::static_pointer_cast<DCContinuousFactor>(dcContinuousFactors_[j]);
     dcContinuousFactor->updateDiscrete(discreteVals);
     for (const gtsam::Key &k : dcContinuousFactor->keys()) {
       newAffectedKeys[j].insert(k);

--- a/src/HybridFactorGraph.cpp
+++ b/src/HybridFactorGraph.cpp
@@ -12,16 +12,16 @@ namespace dcsam {
 HybridFactorGraph::HybridFactorGraph() {}
 
 void HybridFactorGraph::push_nonlinear(
-    boost::shared_ptr<gtsam::NonlinearFactor> nonlinearFactor) {
+    std::shared_ptr<gtsam::NonlinearFactor> nonlinearFactor) {
   nonlinearGraph_.push_back(nonlinearFactor);
 }
 
 void HybridFactorGraph::push_discrete(
-    boost::shared_ptr<gtsam::DiscreteFactor> discreteFactor) {
+    std::shared_ptr<gtsam::DiscreteFactor> discreteFactor) {
   discreteGraph_.push_back(discreteFactor);
 }
 
-void HybridFactorGraph::push_dc(boost::shared_ptr<DCFactor> dcFactor) {
+void HybridFactorGraph::push_dc(std::shared_ptr<DCFactor> dcFactor) {
   dcGraph_.push_back(dcFactor);
 }
 


### PR DESCRIPTION
This seemed to be an issue for migrating to the latest GTSAM version, but I want to make sure it is still compatible with 4.2a8.